### PR TITLE
Ensure config.store object is not mutated

### DIFF
--- a/lib/reducersFor.js
+++ b/lib/reducersFor.js
@@ -20,7 +20,7 @@ function emptyState(config) {
       return [];
     default:
       return SI([]);
-  } 
+  }
 }
 
 function reducersFor(resourceName, args) {
@@ -34,7 +34,7 @@ function reducersFor(resourceName, args) {
     store:        constants.STORE_SI,
   };
 
-  var config      = _.defaults(args, defaults);
+  var config      = _.assign(defaults, args);
 
   return function reducers(state, action) {
     state = state || emptyState(config);


### PR DESCRIPTION
I noticed that if you want to create a bunch of reducers, and use the
same config object for each, the object gets mutated, which means that
`resourceName` gets defined by the first reducer, and not changed for
later ones

e.g.

```javascript
const storeOptions = { key: '_id', store: reduxCrud.STORE_MUTABLE };

const users = reduxCrud.reducersFor('users', storeOptions);
const profiles = reduxCrud.reducersFor('profiles', storeOptions);
const hats = reduxCrud.reducersFor('hats', storeOptions);
```

This results in broken error messages, where the wrong store appears to
be erroring (and possibly breaks other things).

Switched from _.defaults(args, defaults) to _.assign(defaults, args) to
ensure we mutate the defaults object (which is created per store already)
instead.