### PR TITLE
Make the "your config.key, or your data, hasn't got the right `key` field" error message a little clearer.

### DIFF
--- a/lib/utils/assertAllHaveKeys.js
+++ b/lib/utils/assertAllHaveKeys.js
@@ -3,5 +3,5 @@ var _ = require('lodash');
 module.exports = function(config, reducerName, records) {
   // All given records must have a key
   var allKeys = _.all(records, config.key);
-  if (!allKeys) throw new Error(reducerName + ': Expected to have all records with ' + config.key);
+  if (!allKeys) throw new Error(reducerName + ': Expected all records to have a value for the store\'s key `' + config.key + '`');
 }


### PR DESCRIPTION
I struggled to parse the error message for when my data was missing an id prop, I think this is maybe clearer?

![app-name 2015-12-10 11-43-05](https://cloud.githubusercontent.com/assets/78225/11714597/3d7a8d24-9f33-11e5-9ee7-034cd7d28d72.png)
