### PR TITLE
Respect store immutability choices when adding a new record in succes…

### DIFF
--- a/lib/reducers/create/success.js
+++ b/lib/reducers/create/success.js
@@ -40,6 +40,10 @@ function success(config, current, addedRecord, clientGenKey) {
 
   // add if not updated
   if (!done) {
+    if (config.store === constants.STORE_IMMUTABLE) {
+      addedRecord = fromJS(addedRecord);
+    }
+    
     updatedCollection = updatedCollection.concat([addedRecord]);
   }
 


### PR DESCRIPTION
I'm using sockets to transmit resource creations on `createSuccess`. I was noticing that these were not immutable objects causing all sorts of funky stuff to happen. This fixes that issue.