### PR TITLE
WIP Fix bug where record key wouldn’t be updated with actual ID

### DIFF
--- a/dist/reducers/map/create/success.js
+++ b/dist/reducers/map/create/success.js
@@ -10,32 +10,13 @@ var invariantArgs = {
 function success(config, current, addedRecord, clientGenKey) {
     invariants_1.default(invariantArgs, config, current, addedRecord);
     var key = config.key;
-    var done = false;
     var addedRecordKey = addedRecord[key];
-    // Update existing records
-    var updatedCollection = r.map(function (existingRecord) {
-        var recordKey = existingRecord[key];
-        if (recordKey == null)
-            throw new Error('Expected record to have ' + key);
-        var isSameKey = recordKey === addedRecordKey;
-        var isSameClientGetKey = (clientGenKey != null && clientGenKey === recordKey);
-        if (isSameKey || isSameClientGetKey) {
-            done = true;
-            return addedRecord;
-        }
-        else {
-            return existingRecord;
-        }
-    })(current);
-    // Add if not updated
-    if (!done) {
-        var merge = (_a = {},
-            _a[addedRecordKey] = addedRecord,
-            _a);
-        updatedCollection = r.merge(updatedCollection, merge);
+    var addedRecordKeyLens = r.lensProp(addedRecordKey);
+    var clientGenKeyLens = r.lensProp(clientGenKey);
+    if (r.view(clientGenKeyLens, current)) {
+        return r.set(addedRecordKeyLens, addedRecord, r.dissoc(clientGenKey, current));
     }
-    return updatedCollection;
-    var _a;
+    return r.set(addedRecordKeyLens, addedRecord, current);
 }
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = success;

--- a/dist/reducers/map/create/success.test.js
+++ b/dist/reducers/map/create/success.test.js
@@ -20,7 +20,7 @@ function getCurrent() {
         }
     };
 }
-ava_1.default(subject + "it throws if it cannot find config.key", function (t) {
+ava_1.default(subject + " it throws if it cannot find config.key", function (t) {
     var curr = getCurrent();
     var record = {};
     var config = {
@@ -31,7 +31,7 @@ ava_1.default(subject + "it throws if it cannot find config.key", function (t) {
     };
     t.throws(f, /users.createSuccess: Expected config.key/);
 });
-ava_1.default(subject + "doesnt mutate the original collection", function (t) {
+ava_1.default(subject + " doesnt mutate the original collection", function (t) {
     var curr = getCurrent();
     var record = {
         id: 3,
@@ -41,7 +41,7 @@ ava_1.default(subject + "doesnt mutate the original collection", function (t) {
     t.is(r.values(updated).length, 3);
     t.is(r.values(curr).length, 2);
 });
-ava_1.default(subject + "throws if given an array", function (t) {
+ava_1.default(subject + " throws if given an array", function (t) {
     var curr = getCurrent();
     var record = [];
     function fn() {
@@ -49,7 +49,7 @@ ava_1.default(subject + "throws if given an array", function (t) {
     }
     t.throws(fn, TypeError);
 });
-ava_1.default(subject + "adds the record", function (t) {
+ava_1.default(subject + " adds the record", function (t) {
     var curr = getCurrent();
     var record = {
         id: 3,
@@ -74,7 +74,7 @@ ava_1.default(subject + " doesnt mutate the given record", function (t) {
     var updated = success_1.default(config, curr, original);
     t.deepEqual(original, expected);
 });
-ava_1.default(subject + "merges if exists", function (t) {
+ava_1.default(subject + " merges if exists", function (t) {
     var curr = getCurrent();
     var record = {
         id: 2,
@@ -85,15 +85,17 @@ ava_1.default(subject + "merges if exists", function (t) {
     t.is(updated["2"].id, 2);
     t.is(updated["2"].name, "Green");
 });
-ava_1.default(subject + "uses the given key", function (t) {
+ava_1.default(subject + " uses the given key", function (t) {
     var config = {
         key: "_id",
         resourceName: "users",
     };
-    var curr = [{
+    var curr = {
+        2: {
             _id: 2,
             name: "Blue"
-        }];
+        }
+    };
     var record = {
         _id: 2,
         name: "Green"
@@ -101,7 +103,7 @@ ava_1.default(subject + "uses the given key", function (t) {
     var updated = success_1.default(config, curr, record);
     t.is(r.values(updated).length, 1);
 });
-ava_1.default(subject + "it throws when record doesnt have an id", function (t) {
+ava_1.default(subject + " it throws when record doesnt have an id", function (t) {
     var curr = getCurrent();
     var record = {
         name: "Green"
@@ -111,22 +113,25 @@ ava_1.default(subject + "it throws when record doesnt have an id", function (t) 
     };
     t.throws(f, /users.createSuccess: Expected record to have .id/);
 });
-ava_1.default(subject + "it uses the cid", function (t) {
+ava_1.default(subject + " it uses the cid", function (t) {
     var cid = "abc";
-    var curr = [
-        {
-            id: cid,
-            name: "Blue"
+    var curr = {
+        "abc": {
+            id: "abc",
+            name: "Green"
         }
-    ];
+    };
     var record = {
         id: 3,
         name: "Green"
     };
     var updated = success_1.default(config, curr, record, cid);
+    var actualKeys = r.keys(updated);
+    var expectedKeys = ["3"]; // Verify that key was updated too
+    t.deepEqual(actualKeys, expectedKeys);
     t.is(r.values(updated).length, 1);
 });
-ava_1.default(subject + "removes busy and pendingCreate", function (t) {
+ava_1.default(subject + " removes busy and pendingCreate", function (t) {
     var curr = {
         2: {
             busy: true,

--- a/src/reducers/map/create/success.test.ts
+++ b/src/reducers/map/create/success.test.ts
@@ -23,7 +23,7 @@ function getCurrent() {
 	}
 }
 
-test(subject + "it throws if it cannot find config.key", function(t) {
+test(subject + " it throws if it cannot find config.key", function(t) {
 	var curr = getCurrent()
 	var record = {}
 	var config = {
@@ -35,7 +35,7 @@ test(subject + "it throws if it cannot find config.key", function(t) {
 	t.throws(f, /users.createSuccess: Expected config.key/)
 })
 
-test(subject + "doesnt mutate the original collection", function(t){
+test(subject + " doesnt mutate the original collection", function(t){
 	var curr = getCurrent()
 	var record = {
 		id: 3,
@@ -47,7 +47,7 @@ test(subject + "doesnt mutate the original collection", function(t){
 	t.is(r.values(curr).length, 2)
 })
 
-test(subject + "throws if given an array", function(t) {
+test(subject + " throws if given an array", function(t) {
 	var curr    = getCurrent()
 	var record = []
 	function fn() {
@@ -57,7 +57,7 @@ test(subject + "throws if given an array", function(t) {
 	t.throws(fn, TypeError)
 })
 
-test(subject + "adds the record", function(t) {
+test(subject + " adds the record", function(t) {
 	var curr = getCurrent()
 	var record = {
 		id: 3,
@@ -88,7 +88,7 @@ test(subject + " doesnt mutate the given record", function(t) {
 	t.deepEqual(original, expected)
 })
 
-test(subject + "merges if exists", function(t) {
+test(subject + " merges if exists", function(t) {
 	var curr = getCurrent()
 	var record = {
 		id: 2,
@@ -101,25 +101,28 @@ test(subject + "merges if exists", function(t) {
 	t.is(updated["2"].name, "Green")
 })
 
-test(subject + "uses the given key", function(t) {
+test(subject + " uses the given key", function(t) {
 	var config = {
 		key:          "_id",
 		resourceName: "users",
 	}
-	var curr = [{
-		_id: 2,
-		name: "Blue"
-	}]
+	var curr = {
+    2: {
+      _id: 2,
+      name: "Blue"
+    }
+	}
 	var record = {
 		_id: 2,
 		name: "Green"
 	}
+
 	var updated = reducer(config, curr, record)
 
 	t.is(r.values(updated).length, 1)
 })
 
-test(subject + "it throws when record doesnt have an id", function(t) {
+test(subject + " it throws when record doesnt have an id", function(t) {
 	var curr = getCurrent()
 	var record = {
 		name: "Green"
@@ -131,23 +134,28 @@ test(subject + "it throws when record doesnt have an id", function(t) {
 	t.throws(f, /users.createSuccess: Expected record to have .id/)
 })
 
-test(subject + "it uses the cid", function(t) {
+test(subject + " it uses the cid", function(t) {
 	var cid = "abc"
-	var curr = [
-		{
-			id: cid,
-			name: "Blue"
+	var curr = {
+		"abc": {
+			id: "abc",
+			name: "Green"
 		}
-	]
+	}
 	var record = {
 		id: 3,
 		name: "Green"
 	}
+
 	var updated = reducer(config, curr, record, cid)
+	var actualKeys = r.keys(updated)
+	var expectedKeys = ["3"] // Verify that key was updated too
+
+	t.deepEqual(actualKeys, expectedKeys)
 	t.is(r.values(updated).length, 1)
 })
 
-test(subject + "removes busy and pendingCreate", function(t) {
+test(subject + " removes busy and pendingCreate", function(t) {
 	var curr = {
 		2: {
 			busy: true,

--- a/src/reducers/map/create/success.ts
+++ b/src/reducers/map/create/success.ts
@@ -14,31 +14,15 @@ var invariantArgs: InvariantsBaseArgs = {
 export default function success(config: Config, current: Map<any>, addedRecord: any, clientGenKey?: string): Map<any> {
 	invariants(invariantArgs, config, current, addedRecord)
 
-	var key = config.key
-	var done = false
-	var addedRecordKey = addedRecord[key]
+  var key = config.key
+  var addedRecordKey = addedRecord[key]
 
-	// Update existing records
-	var updatedCollection = r.map((existingRecord) => {
-		var recordKey = existingRecord[key]
-		if (recordKey == null) throw new Error('Expected record to have ' + key)
-		var isSameKey = recordKey === addedRecordKey
-		var isSameClientGetKey = (clientGenKey != null && clientGenKey === recordKey)
-		if (isSameKey || isSameClientGetKey) {
-			done = true
-			return addedRecord
-		} else {
-			return existingRecord
-		}
-	})(current)
+  var addedRecordKeyLens = r.lensProp(addedRecordKey)
+  var clientGenKeyLens = r.lensProp(clientGenKey)
 
-	// Add if not updated
-	if (!done) {
-		var merge = {
-			[addedRecordKey]: addedRecord
-		}
-		updatedCollection = r.merge(updatedCollection, merge)
-	}
+  if (r.view(clientGenKeyLens, current)) {
+    return r.set(addedRecordKeyLens, addedRecord, r.dissoc(clientGenKey, current))
+  }
 
-	return updatedCollection
+  return r.set(addedRecordKeyLens, addedRecord, current)
 }


### PR DESCRIPTION
Previously the create success reducer would update the record, but not update the record key if using a cid for the map store. Would end up with something like this:

```
{
  ‘myCid123’: {
	id: 1234,
	...
  }
}
```

Also cleaned up the create success reducer quite a bit. All tests pass and everything seems to work in my app, but I'm still a little worried maybe I missed something when replacing the previous logic?

BTW @sporto Thank you for adding the Map store!!!