### PR TITLE
Fixed optional clientGeneratedKey for List reducer

### DIFF
--- a/dist/reducers/list/create/success.js
+++ b/dist/reducers/list/create/success.js
@@ -7,21 +7,21 @@ var invariantArgs = {
     reducerName: reducerName,
     canBeArray: false,
 };
-function success(config, current, addedRecord, clientGenKey) {
+function success(config, current, addedRecord, clientGeneratedKey) {
     invariants_1.default(invariantArgs, config, current, addedRecord);
     var key = config.key;
     var done = false;
-    // Keep the clientGenKey if provided
-    addedRecord = r.merge(addedRecord, (_a = {},
-        _a[constants_1.default.SPECIAL_KEYS.CLIENT_GENERATED_ID] = clientGenKey,
-        _a));
-    // Update existing records
+    if (clientGeneratedKey != null) {
+        addedRecord = r.merge(addedRecord, (_a = {},
+            _a[constants_1.default.SPECIAL_KEYS.CLIENT_GENERATED_ID] = clientGeneratedKey,
+            _a));
+    }
     var updatedCollection = current.map(function (record) {
         var recordKey = record[key];
         if (recordKey == null)
             throw new Error('Expected record to have ' + key);
         var isSameKey = recordKey === addedRecord[key];
-        var isSameClientGetKey = (clientGenKey != null && clientGenKey === recordKey);
+        var isSameClientGetKey = (clientGeneratedKey != null && clientGeneratedKey === recordKey);
         if (isSameKey || isSameClientGetKey) {
             done = true;
             return addedRecord;

--- a/src/reducers/list/create/success.ts
+++ b/src/reducers/list/create/success.ts
@@ -10,23 +10,25 @@ var invariantArgs: InvariantsBaseArgs = {
 	canBeArray: false,
 }
 
-export default function success(config: Config, current: Array<any>, addedRecord: any, clientGenKey?: string): Array<any> {
+export default function success(config: Config, current: Array<any>, addedRecord: any, clientGeneratedKey?: string): Array<any> {
 	invariants(invariantArgs, config, current, addedRecord)
 
 	var key = config.key
 	var done = false
 
-	// Keep the clientGenKey if provided
-	addedRecord = r.merge(addedRecord, {
-		[constants.SPECIAL_KEYS.CLIENT_GENERATED_ID]: clientGenKey,
-	})
+	// Keep the clientGeneratedKey if provided
+	if (clientGeneratedKey != null) {
+		addedRecord = r.merge(addedRecord, {
+			[constants.SPECIAL_KEYS.CLIENT_GENERATED_ID]: clientGeneratedKey,
+		})
+	}
 
 	// Update existing records
 	var updatedCollection = current.map(function (record) {
 		var recordKey = record[key]
 		if (recordKey == null) throw new Error('Expected record to have ' + key)
 		var isSameKey = recordKey === addedRecord[key]
-		var isSameClientGetKey = (clientGenKey != null && clientGenKey === recordKey)
+		var isSameClientGetKey = (clientGeneratedKey != null && clientGeneratedKey === recordKey)
 		if (isSameKey || isSameClientGetKey) {
 			done = true
 			return addedRecord


### PR DESCRIPTION
The List reducer was not properly ignoring the client generated key if it was not provided.