### PR TITLE
Bugfix: merge record contents with existing record keyed by cid on createSuccess

### DIFF
--- a/dist/reducers/map/create/success.js
+++ b/dist/reducers/map/create/success.js
@@ -14,7 +14,7 @@ function success(config, current, addedRecord, clientGeneratedKey) {
     var addedRecordKeyLens = r.lensProp(addedRecordKey);
     // Keep the cuid in the record if there is one
     if (clientGeneratedKey != null) {
-        addedRecord = r.merge(addedRecordKey, (_a = {},
+        addedRecord = r.merge(addedRecord, (_a = {},
             _a[constants_1.default.SPECIAL_KEYS.CLIENT_GENERATED_ID] = clientGeneratedKey,
             _a));
     }

--- a/dist/reducers/map/create/success.test.js
+++ b/dist/reducers/map/create/success.test.js
@@ -1,4 +1,12 @@
 "use strict";
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
 var r = require("ramda");
 var ava_1 = require("ava");
 var constants_1 = require("../../../constants");
@@ -113,7 +121,7 @@ ava_1.default(subject + " it throws when record doesn't have an id", function (t
     };
     t.throws(f, /users.createSuccess: Expected record to have .id/);
 });
-ava_1.default(subject + " it uses the cid", function (t) {
+ava_1.default(subject + " it uses the cid to merge the record", function (t) {
     var cid = "abc";
     var curr = (_a = {},
         _a[cid] = {
@@ -128,6 +136,8 @@ ava_1.default(subject + " it uses the cid", function (t) {
     var updated = success_1.default(config, curr, record, cid);
     var actualKeys = r.keys(updated);
     var expectedKeys = ["3"]; // Verify that key was updated too
+    // Verify that the record was merged
+    t.same(updated['3'], __assign({ _cid: 'abc' }, record));
     t.same(actualKeys, expectedKeys);
     var _a;
 });

--- a/src/reducers/map/create/success.test.ts
+++ b/src/reducers/map/create/success.test.ts
@@ -134,7 +134,7 @@ test(subject + " it throws when record doesn't have an id", function(t) {
 	t.throws(f, /users.createSuccess: Expected record to have .id/)
 })
 
-test(subject + " it uses the cid", function(t) {
+test(subject + " it uses the cid to merge the record", function(t) {
 	var cid = "abc"
 	var curr = {
 		[cid]: {
@@ -150,6 +150,12 @@ test(subject + " it uses the cid", function(t) {
 	var updated = reducer(config, curr, record, cid)
 	var actualKeys = r.keys(updated)
 	var expectedKeys = ["3"] // Verify that key was updated too
+
+	// Verify that the record was merged
+	t.same(updated['3'], {
+		_cid: 'abc',
+		...record
+	})
 
 	t.same(actualKeys, expectedKeys)
 })

--- a/src/reducers/map/create/success.ts
+++ b/src/reducers/map/create/success.ts
@@ -20,7 +20,7 @@ export default function success(config: Config, current: Map<any>, addedRecord: 
 
 	// Keep the cuid in the record if there is one
 	if (clientGeneratedKey != null) {
-		addedRecord = r.merge(addedRecordKey,  {
+		addedRecord = r.merge(addedRecord,  {
 			[constants.SPECIAL_KEYS.CLIENT_GENERATED_ID]: clientGeneratedKey,
 		})
 	}


### PR DESCRIPTION
Using the new Map reducer, creating a record with a cid via createStart and running createSuccess with the new record data and the cid results in a record empty save for a _cid property.

This looks like a typo and a missed test (merging into the record's key rather than the record), so I added a test to confirm and fixed. Let me know if I've missed something here.

Thanks for the Map reducers, I'd forked your repository and added the same functionality with a view to a PR but the new Typescript implementation is much nicer.