### PR TITLE
Exclude dist in tsconfig / Generic type for record

### DIFF
--- a/dist/actionCreatorsFor.d.ts
+++ b/dist/actionCreatorsFor.d.ts
@@ -1,12 +1,12 @@
 import { Config } from "./types";
-declare function actionCreatorsFor(resourceName: string, config?: Config): {
+declare function actionCreatorsFor<T>(resourceName: string, config?: Config): {
     fetchStart(data?: any): {
         data: any;
         type: any;
     };
-    fetchSuccess(records?: any, data?: any): {
+    fetchSuccess(records?: T[], data?: any): {
         data: any;
-        records: any;
+        records: T[];
         type: any;
     };
     fetchError(error?: any, data?: any): {
@@ -14,53 +14,53 @@ declare function actionCreatorsFor(resourceName: string, config?: Config): {
         error: any;
         type: any;
     };
-    createStart(record?: any, data?: any): {
+    createStart(record?: T, data?: any): {
         data: any;
-        record: any;
+        record: T;
         type: any;
     };
-    createSuccess(record?: any, clientGeneratedKey?: any, data?: any): {
+    createSuccess(record?: T, clientGeneratedKey?: any, data?: any): {
         cid: any;
         data: any;
-        record: any;
+        record: T;
         type: any;
     };
-    createError(error?: any, record?: any, data?: any): {
+    createError(error?: any, record?: T, data?: any): {
         data: any;
         error: any;
-        record: any;
+        record: T;
         type: any;
     };
-    updateStart(record?: any, data?: any): {
+    updateStart(record?: T, data?: any): {
         data: any;
-        record: any;
+        record: T;
         type: any;
     };
-    updateSuccess(record?: any, data?: any): {
+    updateSuccess(record?: T, data?: any): {
         data: any;
-        record: any;
+        record: T;
         type: any;
     };
-    updateError(error?: any, record?: any, data?: any): {
-        data: any;
-        error: any;
-        record: any;
-        type: any;
-    };
-    deleteStart(record?: any, data?: any): {
-        data: any;
-        record: any;
-        type: any;
-    };
-    deleteSuccess(record?: any, data?: any): {
-        data: any;
-        record: any;
-        type: any;
-    };
-    deleteError(error?: any, record?: any, data?: any): {
+    updateError(error?: any, record?: T, data?: any): {
         data: any;
         error: any;
-        record: any;
+        record: T;
+        type: any;
+    };
+    deleteStart(record?: T, data?: any): {
+        data: any;
+        record: T;
+        type: any;
+    };
+    deleteSuccess(record?: T, data?: any): {
+        data: any;
+        record: T;
+        type: any;
+    };
+    deleteError(error?: any, record?: T, data?: any): {
+        data: any;
+        error: any;
+        record: T;
         type: any;
     };
 };

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,13 +1,14 @@
 import { Config } from "./types";
+export * from "./types";
 declare var _default: {
-    actionCreatorsFor: (resourceName: string, config?: Config) => {
+    actionCreatorsFor: <T>(resourceName: string, config?: Config) => {
         fetchStart(data?: any): {
             data: any;
             type: any;
         };
-        fetchSuccess(records?: any, data?: any): {
+        fetchSuccess(records?: T[], data?: any): {
             data: any;
-            records: any;
+            records: T[];
             type: any;
         };
         fetchError(error?: any, data?: any): {
@@ -15,53 +16,53 @@ declare var _default: {
             error: any;
             type: any;
         };
-        createStart(record?: any, data?: any): {
+        createStart(record?: T, data?: any): {
             data: any;
-            record: any;
+            record: T;
             type: any;
         };
-        createSuccess(record?: any, clientGeneratedKey?: any, data?: any): {
+        createSuccess(record?: T, clientGeneratedKey?: any, data?: any): {
             cid: any;
             data: any;
-            record: any;
+            record: T;
             type: any;
         };
-        createError(error?: any, record?: any, data?: any): {
+        createError(error?: any, record?: T, data?: any): {
             data: any;
             error: any;
-            record: any;
+            record: T;
             type: any;
         };
-        updateStart(record?: any, data?: any): {
+        updateStart(record?: T, data?: any): {
             data: any;
-            record: any;
+            record: T;
             type: any;
         };
-        updateSuccess(record?: any, data?: any): {
+        updateSuccess(record?: T, data?: any): {
             data: any;
-            record: any;
+            record: T;
             type: any;
         };
-        updateError(error?: any, record?: any, data?: any): {
-            data: any;
-            error: any;
-            record: any;
-            type: any;
-        };
-        deleteStart(record?: any, data?: any): {
-            data: any;
-            record: any;
-            type: any;
-        };
-        deleteSuccess(record?: any, data?: any): {
-            data: any;
-            record: any;
-            type: any;
-        };
-        deleteError(error?: any, record?: any, data?: any): {
+        updateError(error?: any, record?: T, data?: any): {
             data: any;
             error: any;
-            record: any;
+            record: T;
+            type: any;
+        };
+        deleteStart(record?: T, data?: any): {
+            data: any;
+            record: T;
+            type: any;
+        };
+        deleteSuccess(record?: T, data?: any): {
+            data: any;
+            record: T;
+            type: any;
+        };
+        deleteError(error?: any, record?: T, data?: any): {
+            data: any;
+            error: any;
+            record: T;
             type: any;
         };
     };

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -22,3 +22,11 @@ export interface StoreList {
 export interface StoreMap {
     remove: (config: Config, current: Map<any>, record: any) => Map<any>;
 }
+export interface Record {
+    id: string | number;
+    _cid?: string | number;
+    busy?: boolean;
+    deleted?: boolean;
+    pendingCreate?: boolean;
+    pendingUpdate?: boolean;
+}

--- a/src/actionCreatorsFor.ts
+++ b/src/actionCreatorsFor.ts
@@ -10,7 +10,7 @@ import { Config, ReducerName } from "./types"
 
 // const invariant = require("invariant")
 
-function actionCreatorsFor(resourceName: string, config?: Config) {
+function actionCreatorsFor<T>(resourceName: string, config?: Config) {
 	if (resourceName == null) throw new Error("actionCreatorsFor: Expected resourceName")
 
 	config = config || getDefaultConfig(resourceName)
@@ -41,7 +41,7 @@ function actionCreatorsFor(resourceName: string, config?: Config) {
 			}
 		},
 
-		fetchSuccess(records?, data?) {
+		fetchSuccess(records?: T[], data?) {
 			var name: ReducerName = "fetchSuccess"
 			assertManyRecords(name, records)
 
@@ -63,7 +63,7 @@ function actionCreatorsFor(resourceName: string, config?: Config) {
 			}
 		},
 
-		createStart(record?, data?) {
+		createStart(record?: T, data?) {
 			var name: ReducerName = "createStart"
 			assertOneRecord(name, record)
 
@@ -74,7 +74,7 @@ function actionCreatorsFor(resourceName: string, config?: Config) {
 			}
 		},
 
-		createSuccess(record?, clientGeneratedKey?, data?) {
+		createSuccess(record?: T, clientGeneratedKey?, data?) {
 			var name: ReducerName = "createSuccess"
 			assertOneRecord(name, record)
 
@@ -86,7 +86,7 @@ function actionCreatorsFor(resourceName: string, config?: Config) {
 			}
 		},
 
-		createError(error?, record?, data?) {
+		createError(error?, record?: T, data?) {
 			var name: ReducerName = "createError"
 			assertError(name, error)
 			assertOneRecord(name, record)
@@ -99,7 +99,7 @@ function actionCreatorsFor(resourceName: string, config?: Config) {
 			}
 		},
 
-		updateStart(record?, data?) {
+		updateStart(record?: T, data?) {
 			var name: ReducerName = "updateStart"
 			assertOneRecord(name, record)
 
@@ -110,7 +110,7 @@ function actionCreatorsFor(resourceName: string, config?: Config) {
 			}
 		},
 
-		updateSuccess(record?, data?) {
+		updateSuccess(record?: T, data?) {
 			var name: ReducerName = "updateSuccess"
 			assertOneRecord(name, record)
 
@@ -121,7 +121,7 @@ function actionCreatorsFor(resourceName: string, config?: Config) {
 			}
 		},
 
-		updateError(error?, record?, data?) {
+		updateError(error?, record?: T, data?) {
 			var name: ReducerName = "updateError"
 			assertError(name, error)
 			assertOneRecord(name, record)
@@ -134,7 +134,7 @@ function actionCreatorsFor(resourceName: string, config?: Config) {
 			}
 		},
 
-		deleteStart(record?, data?) {
+		deleteStart(record?: T, data?) {
 			var name: ReducerName = "deleteStart"
 			assertOneRecord(name, record)
 
@@ -145,7 +145,7 @@ function actionCreatorsFor(resourceName: string, config?: Config) {
 			}
 		},
 
-		deleteSuccess(record?, data?) {
+		deleteSuccess(record?: T, data?) {
 			var name: ReducerName = "deleteSuccess"
 			assertOneRecord(name, record)
 
@@ -156,7 +156,7 @@ function actionCreatorsFor(resourceName: string, config?: Config) {
 			}
 		},
 
-		deleteError(error?, record?, data?) {
+		deleteError(error?, record?: T, data?) {
 			var name: ReducerName = "deleteError"
 			assertError(name, error)
 			assertOneRecord(name, record)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import constants         from "./constants"
 import List              from "./reducers/list"
 import Map               from "./reducers/map"
 
+export * from "./types";
+
 export default {
 	actionCreatorsFor,
 	actionTypesFor,

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,3 +39,12 @@ export interface StoreList {
 export interface StoreMap {
 	remove: (config: Config, current: Map<any>, record: any) => Map<any>
 }
+
+export interface Record {
+	id: string|number;
+	_cid?: string|number;
+	busy?: boolean;
+	deleted?: boolean;
+	pendingCreate?: boolean;
+	pendingUpdate?: boolean;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
 		"target": "es5"
 	},
    "exclude": [
+		"dist",
 		"node_modules",
 		"example"
 	]


### PR DESCRIPTION
1. Build fails because dist directory is not exclude from compilation (and d.ts declarations files are typescript files)

2. Generic type in actionCreatorsFor is usefull for typescript users.
I exposed your "types" in index file to be able to use them to type some variables in user code. In addition I added a simple "Record" interface with all default constants used in reducers. Record interface can't be used in internal code because constants are configurable.

<img width="669" alt="capture d ecran 2017-04-11 a 12 48 23" src="https://cloud.githubusercontent.com/assets/2361402/24905726/3015268c-1eb5-11e7-91a2-bcfa84456aee.png">

<img width="824" alt="capture d ecran 2017-04-11 a 12 47 52" src="https://cloud.githubusercontent.com/assets/2361402/24905699/1bb8ca22-1eb5-11e7-816e-8d57aa1a3e85.png">