### PR TITLE
Ramda imports are now module-specific to reduce build size

### DIFF
--- a/src/actionCreatorsFor.ts
+++ b/src/actionCreatorsFor.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as merge from "ramda/src/merge";
 import * as invariant from "invariant";
 
 import actionTypesFor from "./actionTypesFor";
@@ -15,7 +15,7 @@ function actionCreatorsFor<T>(resourceName: string, config?: Config) {
     throw new Error("actionCreatorsFor: Expected resourceName");
 
   config = config || getDefaultConfig(resourceName);
-  config = r.merge(config, {resourceName});
+  config = merge(config, {resourceName});
 
   const actionTypes = actionTypesFor(resourceName);
   const key = config.key || constants.DEFAULT_KEY;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,12 +1,12 @@
 import test from "ava";
-import * as r from "ramda";
+import * as is from "ramda/src/is";
 import index from "./index";
 
 test("it has the expected functions", function(t) {
-  t.truthy(r.is(Function, index.actionCreatorsFor));
-  t.truthy(r.is(Function, index.actionTypesFor));
-  t.truthy(r.is(Object, index.List));
-  t.truthy(r.is(Function, index.List.reducersFor));
-  t.truthy(r.is(Object, index.Map));
-  t.truthy(r.is(Function, index.Map.reducersFor));
+  t.truthy(is(Function, index.actionCreatorsFor));
+  t.truthy(is(Function, index.actionTypesFor));
+  t.truthy(is(Object, index.List));
+  t.truthy(is(Function, index.List.reducersFor));
+  t.truthy(is(Object, index.Map));
+  t.truthy(is(Function, index.Map.reducersFor));
 });

--- a/src/reducers/common/create/start.ts
+++ b/src/reducers/common/create/start.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as merge from "ramda/src/merge"
 import constants from "../../../constants";
 
 export function prepareRecord(record: Object) {
@@ -7,5 +7,5 @@ export function prepareRecord(record: Object) {
     [constants.SPECIAL_KEYS.PENDING_CREATE]: true
   };
 
-  return r.merge(record, recordStatus);
+  return merge(record, recordStatus);
 }

--- a/src/reducers/common/delete/start.ts
+++ b/src/reducers/common/delete/start.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as merge from "ramda/src/merge"
 import constants from "../../../constants";
 
 export function prepareRecord(record: Object) {
@@ -7,5 +7,5 @@ export function prepareRecord(record: Object) {
     [constants.SPECIAL_KEYS.BUSY]: true
   };
 
-  return r.merge(record, recordStatus);
+  return merge(record, recordStatus);
 }

--- a/src/reducers/common/reducersFor.ts
+++ b/src/reducers/common/reducersFor.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as merge from "ramda/src/merge"
 
 import actionTypesFor from "../../actionTypesFor";
 import constants from "../../constants";
@@ -14,7 +14,7 @@ function reducersFor(resourceName: string, args = {}, emptyState, reducers) {
     resourceName: resourceName
   };
 
-  var config = r.merge(defaults, args);
+  var config = merge(defaults, args);
 
   return function getReducer(state, action) {
     state = state || emptyState;

--- a/src/reducers/common/update/error.ts
+++ b/src/reducers/common/update/error.ts
@@ -1,6 +1,6 @@
-import * as r from "ramda";
+import * as dissoc from "ramda/src/dissoc"
 import constants from "../../../constants";
 
 export function prepareRecord(record: Object) {
-  return r.dissoc(constants.SPECIAL_KEYS.BUSY, record);
+  return dissoc(constants.SPECIAL_KEYS.BUSY, record);
 }

--- a/src/reducers/common/update/start.ts
+++ b/src/reducers/common/update/start.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as merge from "ramda/src/merge"
 import constants from "../../../constants";
 
 export function prepareRecord(record: Object) {
@@ -7,5 +7,5 @@ export function prepareRecord(record: Object) {
     [constants.SPECIAL_KEYS.PENDING_UPDATE]: true
   };
 
-  return r.merge(record, recordStatus);
+  return merge(record, recordStatus);
 }

--- a/src/reducers/invariants/assertHasKey.ts
+++ b/src/reducers/invariants/assertHasKey.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as forEach from "ramda/src/forEach"
 
 import constants from "../../constants";
 import wrapArray from "../../utils/wrapArray";
@@ -13,7 +13,7 @@ export default function assertHasKey(
   var key = config.key;
   var records = wrapArray(recordOrRecords);
 
-  r.forEach(function(record) {
+  forEach(function(record) {
     if (record[key] == null) {
       throw new Error(scope + ": Expected record to have ." + key);
     }

--- a/src/reducers/list/create/error.test.ts
+++ b/src/reducers/list/create/error.test.ts
@@ -1,5 +1,4 @@
 import test from "ava";
-import * as r from "ramda";
 
 import constants from "../../../constants";
 import reducer from "./error";

--- a/src/reducers/list/create/start.ts
+++ b/src/reducers/list/create/start.ts
@@ -1,5 +1,3 @@
-import * as r from "ramda";
-
 import {prepareRecord} from "../../common/create/start";
 import constants from "../../../constants";
 import invariants from "../invariants";

--- a/src/reducers/list/create/success.ts
+++ b/src/reducers/list/create/success.ts
@@ -1,4 +1,3 @@
-import * as r from "ramda";
 import constants from "../../../constants";
 import invariants from "../invariants";
 

--- a/src/reducers/list/delete/error.ts
+++ b/src/reducers/list/delete/error.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as omit from "ramda/src/omit"
 
 import constants from "../../../constants";
 import findByKey from "../../../utils/findByKey";
@@ -23,7 +23,7 @@ export default function error(
   var key = config.key;
   var deleteId = record[key];
   var deleteRecord = findByKey(current, key, deleteId);
-  deleteRecord = r.omit(["deleted", "busy"], deleteRecord);
+  deleteRecord = omit(["deleted", "busy"], deleteRecord);
 
   return store.merge(current, deleteRecord, key);
 }

--- a/src/reducers/list/delete/start.ts
+++ b/src/reducers/list/delete/start.ts
@@ -1,5 +1,3 @@
-import * as r from "ramda";
-
 import {prepareRecord} from "../../common/delete/start";
 import constants from "../../../constants";
 import findByKey from "../../../utils/findByKey";

--- a/src/reducers/list/delete/success.ts
+++ b/src/reducers/list/delete/success.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as reject from "ramda/src/reject"
 
 import invariants from "../invariants";
 import constants from "../../../constants";
@@ -25,5 +25,5 @@ export default function success(
     return deleteId == existingRecord[key];
   }
 
-  return r.reject(predicate, current);
+  return reject(predicate, current);
 }

--- a/src/reducers/list/reducersFor.ts
+++ b/src/reducers/list/reducersFor.ts
@@ -1,3 +1,5 @@
+import * as merge from "ramda/src/merge"
+
 import actionTypesFor from "../../actionTypesFor";
 import constants from "../../constants";
 import commonReducersFor from "../common/reducersFor";
@@ -11,8 +13,6 @@ import fetchSuccess from "./fetch/success";
 import updateError from "./update/error";
 import updateStart from "./update/start";
 import updateSuccess from "./update/success";
-import * as r from "ramda";
-
 import {Config, ReducerName} from "../../types";
 
 const baseReducers = {
@@ -29,6 +29,6 @@ const baseReducers = {
 };
 
 export default function reducersFor(resourceName: string, args = {}, deps?) {
-  const reducers = r.merge(baseReducers, deps);
+  const reducers = merge(baseReducers, deps);
   return commonReducersFor(resourceName, args, [], reducers);
 }

--- a/src/reducers/list/store/assert.ts
+++ b/src/reducers/list/store/assert.ts
@@ -1,6 +1,6 @@
-import * as r from "ramda";
+import * as is from "ramda/src/is"
 
 export default function assert(scope: string, current: Array<any>): void {
-  var isArray = r.is(Array, current);
+  var isArray = is(Array, current);
   if (!isArray) throw new Error(scope + ": Expected current to be an array");
 }

--- a/src/reducers/list/store/remove.ts
+++ b/src/reducers/list/store/remove.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as reject from "ramda/src/reject"
 
 import {Config} from "../../../types";
 
@@ -15,5 +15,5 @@ export default function remove(
     return isSameKey;
   }
 
-  return r.reject(predicate, current);
+  return reject(predicate, current);
 }

--- a/src/reducers/list/update/error.ts
+++ b/src/reducers/list/update/error.ts
@@ -1,5 +1,3 @@
-import * as r from "ramda";
-
 import {prepareRecord} from "../../common/update/error";
 import constants from "../../../constants";
 import findByKey from "../../../utils/findByKey";

--- a/src/reducers/list/update/start.ts
+++ b/src/reducers/list/update/start.ts
@@ -1,5 +1,3 @@
-import * as r from "ramda";
-
 import {prepareRecord} from "../../common/update/start";
 import constants from "../../../constants";
 import invariants from "../invariants";

--- a/src/reducers/map/create/error.test.ts
+++ b/src/reducers/map/create/error.test.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as values from "ramda/src/values"
 import test from "ava";
 
 import constants from "../../../constants";
@@ -36,7 +36,7 @@ test(subject + "throws if given an array", function(t) {
 
 test(subject + "removes the record", function(t) {
   var curr = getCurrent();
-  t.deepEqual(r.values(curr).length, 2);
+  t.deepEqual(values(curr).length, 2);
 
   var created = {
     id: "abc",
@@ -44,5 +44,5 @@ test(subject + "removes the record", function(t) {
   };
   var updated = reducer(config, curr, created);
 
-  t.deepEqual(r.values(updated).length, 2);
+  t.deepEqual(values(updated).length, 2);
 });

--- a/src/reducers/map/create/start.test.ts
+++ b/src/reducers/map/create/start.test.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as values from "ramda/src/values"
 import test from "ava";
 
 import constants from "../../../constants";
@@ -49,7 +49,7 @@ test(subject + " adds the new record", function(t) {
   };
   var updated = reducer(config, curr, other);
 
-  t.is(r.values(updated).length, 3, "adds the record");
+  t.is(values(updated).length, 3, "adds the record");
 });
 
 test(subject + "it throws when record doesnt have an id", function(t) {

--- a/src/reducers/map/create/start.ts
+++ b/src/reducers/map/create/start.ts
@@ -1,5 +1,3 @@
-import * as r from "ramda";
-
 import {prepareRecord} from "../../common/create/start";
 import constants from "../../../constants";
 import invariants from "../invariants";

--- a/src/reducers/map/create/success.test.ts
+++ b/src/reducers/map/create/success.test.ts
@@ -1,4 +1,5 @@
-import * as r from "ramda";
+import * as values from "ramda/src/values"
+import * as keys from "ramda/src/keys"
 import test from "ava";
 
 import constants from "../../../constants";
@@ -43,8 +44,8 @@ test(subject + " doesn't mutate the original collection", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 3);
-  t.is(r.values(curr).length, 2);
+  t.is(values(updated).length, 3);
+  t.is(values(curr).length, 2);
 });
 
 test(subject + " throws if given an array", function(t) {
@@ -64,7 +65,7 @@ test(subject + " adds the record", function(t) {
     name: "Green"
   };
   var updated = reducer(config, curr, record);
-  var actual = r.keys(updated);
+  var actual = keys(updated);
   var expected = ["1", "2", "3"];
 
   t.deepEqual(actual, expected);
@@ -96,7 +97,7 @@ test(subject + " merges if exists", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 2);
+  t.is(values(updated).length, 2);
   t.is(updated["2"].id, 2);
   t.is(updated["2"].name, "Green");
 });
@@ -119,7 +120,7 @@ test(subject + " uses the given key", function(t) {
 
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 1);
+  t.is(values(updated).length, 1);
 });
 
 test(subject + " it throws when record doesn't have an id", function(t) {
@@ -151,7 +152,7 @@ test(subject + " uses the cid to merge the record", function(t) {
 
   // It has the expected key
   var expectedKeys = ["3"];
-  var actualKeys = r.keys(updated);
+  var actualKeys = keys(updated);
   t.deepEqual(actualKeys, expectedKeys);
 
   // It merged the record
@@ -193,7 +194,7 @@ test(subject + " removes busy and pendingCreate", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 1);
+  t.is(values(updated).length, 1);
   t.truthy(updated["2"].busy == null, "removes busy");
   t.truthy(updated["2"].pendingCreate == null, "removes pendingCreate");
 });

--- a/src/reducers/map/create/success.ts
+++ b/src/reducers/map/create/success.ts
@@ -1,4 +1,6 @@
-import * as r from "ramda";
+import * as dissoc from "ramda/src/dissoc"
+import * as lensProp from "ramda/src/lensProp"
+import * as set from "ramda/src/set"
 
 import constants from "../../../constants";
 import invariants from "../invariants";
@@ -21,10 +23,10 @@ export default function success(
 
   var key = config.key;
   var addedRecordKey: string = addedRecord[key];
-  var addedRecordKeyLens = r.lensProp(addedRecordKey);
-  var currentWithoutClientGeneratedKey = r.dissoc(clientGeneratedKey, current);
+  var addedRecordKeyLens = lensProp(addedRecordKey);
+  var currentWithoutClientGeneratedKey = dissoc(clientGeneratedKey, current);
 
-  return r.set(
+  return set(
     addedRecordKeyLens,
     addedRecord,
     currentWithoutClientGeneratedKey

--- a/src/reducers/map/delete/error.test.ts
+++ b/src/reducers/map/delete/error.test.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as values from "ramda/src/values"
 import test from "ava";
 
 import constants from "../../../constants";
@@ -58,7 +58,7 @@ test(subject + "removes deleted and busy", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 2, "doesnt remove record");
+  t.is(values(updated).length, 2, "doesnt remove record");
   t.truthy(updated["1"].deleted == null, "removes deleted");
   t.truthy(updated["1"].busy == null, "removes busy");
 

--- a/src/reducers/map/delete/error.ts
+++ b/src/reducers/map/delete/error.ts
@@ -1,4 +1,5 @@
-import * as r from "ramda";
+import * as omit from "ramda/src/omit"
+import * as merge from "ramda/src/merge"
 
 import constants from "../../../constants";
 import findByKey from "../../../utils/findByKey";
@@ -30,8 +31,8 @@ export default function error(
     return current;
   } else {
     // Remove deleted and busy
-    deleteRecord = r.omit(["deleted", "busy"], deleteRecord);
+    deleteRecord = omit(["deleted", "busy"], deleteRecord);
 
-    return r.merge(current, {[deleteId]: deleteRecord});
+    return merge(current, {[deleteId]: deleteRecord});
   }
 }

--- a/src/reducers/map/delete/start.ts
+++ b/src/reducers/map/delete/start.ts
@@ -1,5 +1,3 @@
-import * as r from "ramda";
-
 import {prepareRecord} from "../../common/delete/start";
 import invariants from "../invariants";
 import constants from "../../../constants";

--- a/src/reducers/map/delete/success.test.ts
+++ b/src/reducers/map/delete/success.test.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as values from "ramda/src/values"
 import test from "ava";
 
 import constants from "../../../constants";
@@ -45,7 +45,7 @@ test(subject + "removes the record", function(t) {
   var record = getValid();
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 1, "removes the record");
+  t.is(values(updated).length, 1, "removes the record");
   t.is(updated["1"], undefined);
 });
 
@@ -54,8 +54,8 @@ test(subject + "doesnt mutate the original collection", function(t) {
   var record = getValid();
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(curr).length, 2);
-  t.is(r.values(updated).length, 1);
+  t.is(values(curr).length, 2);
+  t.is(values(updated).length, 1);
 });
 
 test(subject + "uses the given key", function(t) {
@@ -73,7 +73,7 @@ test(subject + "uses the given key", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.deepEqual(r.values(updated).length, 0, "removes the record");
+  t.deepEqual(values(updated).length, 0, "removes the record");
 });
 
 test(subject + "it throws when record dont have an id", function(t) {

--- a/src/reducers/map/delete/success.ts
+++ b/src/reducers/map/delete/success.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as reject from "ramda/src/reject"
 
 import invariants from "../invariants";
 import constants from "../../../constants";
@@ -25,5 +25,5 @@ export default function success(
     return deleteId == existingRecord[key];
   }
 
-  return r.reject(predicate, current);
+  return reject(predicate, current);
 }

--- a/src/reducers/map/fetch/success.test.ts
+++ b/src/reducers/map/fetch/success.test.ts
@@ -1,4 +1,5 @@
-import * as r from "ramda";
+import * as values from "ramda/src/values"
+import * as merge from "ramda/src/merge"
 import test from "ava";
 
 import constants from "../../../constants";
@@ -62,7 +63,7 @@ test(subject + " throws when config.key is wrong", function(t) {
     },
   ];
 
-  var config2 = r.merge(config, {
+  var config2 = merge(config, {
     key: "_id",
   })
 
@@ -82,8 +83,8 @@ test(subject + " doesnt mutate the original collection", function(t) {
   ];
   var updated = reducer(config, curr, more, {});
 
-  t.is(r.values(curr).length, 2);
-  t.is(r.values(updated).length, 3);
+  t.is(values(curr).length, 2);
+  t.is(values(updated).length, 3);
 });
 
 test(subject + " merges", function(t) {
@@ -96,7 +97,7 @@ test(subject + " merges", function(t) {
   ];
   var updated = reducer(config, curr, more, {});
 
-  t.is(r.values(updated).length, 2);
+  t.is(values(updated).length, 2);
   t.is(updated["2"].id, 2);
   t.is(updated["2"].name, "Green");
 });
@@ -111,7 +112,7 @@ test(subject + " replaces", function(t) {
   ];
   const updated = reducer(config, curr, more, {}, true);
 
-  t.is(r.values(updated).length, 1);
+  t.is(values(updated).length, 1);
   t.is(updated["2"].id, 2);
   t.is(updated["2"].name, "Green");
 });
@@ -136,7 +137,7 @@ test(subject + " uses the given key", function(t) {
 
   var updated = reducer(config, curr, more, {});
 
-  t.is(r.values(updated).length, 1);
+  t.is(values(updated).length, 1);
 });
 
 test(subject + " it throws when records dont have an id", function(t) {
@@ -161,5 +162,5 @@ test(subject + " can take one record", function(t) {
   };
   var updated = reducer(config, curr, one, {});
 
-  t.is(r.values(updated).length, 3);
+  t.is(values(updated).length, 3);
 });

--- a/src/reducers/map/fetch/success.ts
+++ b/src/reducers/map/fetch/success.ts
@@ -1,4 +1,6 @@
-import * as r from "ramda";
+import * as indexBy from "ramda/src/indexBy"
+import * as prop from "ramda/src/prop"
+import * as merge from "ramda/src/merge"
 
 import assertAllHaveKeys from "../../../utils/assertAllHaveKeys";
 import constants from "../../../constants";
@@ -28,7 +30,7 @@ export default function success(
   // All given records must have a key
   assertAllHaveKeys(config, reducerName, records);
 
-  const merge = r.indexBy(r.prop(config.key), records);
+  const mergeValues = indexBy(prop(config.key), records);
 
-  return r.merge(replace ? emptyState : current, merge);
+  return merge(replace ? emptyState : current, mergeValues);
 }

--- a/src/reducers/map/reducersFor.ts
+++ b/src/reducers/map/reducersFor.ts
@@ -1,3 +1,5 @@
+import * as merge from "ramda/src/merge"
+
 import actionTypesFor from "../../actionTypesFor";
 import constants from "../../constants";
 import commonReducersFor from "../common/reducersFor";
@@ -11,7 +13,6 @@ import fetchSuccess from "./fetch/success";
 import updateError from "./update/error";
 import updateStart from "./update/start";
 import updateSuccess from "./update/success";
-import * as r from "ramda";
 
 import {Config, ReducerName} from "../../types";
 
@@ -29,6 +30,6 @@ const baseReducers = {
 };
 
 export default function reducersFor(resourceName: string, args = {}, deps?) {
-  const reducers = r.merge(baseReducers, deps);
+  const reducers = merge(baseReducers, deps);
   return commonReducersFor(resourceName, args, {}, reducers);
 }

--- a/src/reducers/map/store/assert.ts
+++ b/src/reducers/map/store/assert.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as is from "ramda/src/is"
 
 import {Map} from "../../../types";
 
@@ -6,6 +6,6 @@ export default function assertValidStore(
   scope: string,
   current: Map<any>
 ): void {
-  if (!r.is(Object, current))
+  if (!is(Object, current))
     throw new Error(scope + ": Expected current to be an object");
 }

--- a/src/reducers/map/store/merge.ts
+++ b/src/reducers/map/store/merge.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as merge from "ramda/src/merge"
 
 import {Config, Map} from "../../../types";
 
@@ -13,5 +13,5 @@ export default function replace(
   var key = config.key;
   var recordKey = record[key];
 
-  return r.merge(current, {[recordKey]: record});
+  return merge(current, {[recordKey]: record});
 }

--- a/src/reducers/map/store/remove.ts
+++ b/src/reducers/map/store/remove.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as omit from "ramda/src/omit"
 
 import {Config, Map} from "../../../types";
 
@@ -10,5 +10,5 @@ export default function remove(
   var key = config.key;
   var recordKey = record[key];
 
-  return r.omit([recordKey], current);
+  return omit([recordKey], current);
 }

--- a/src/reducers/map/update/error.test.ts
+++ b/src/reducers/map/update/error.test.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as values from "ramda/src/values"
 import test from "ava";
 
 import constants from "../../../constants";
@@ -52,7 +52,7 @@ test(subject + "doesnt add record if not there", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 2);
+  t.is(values(updated).length, 2);
 });
 
 test(subject + "removes busy", function(t) {

--- a/src/reducers/map/update/error.ts
+++ b/src/reducers/map/update/error.ts
@@ -1,5 +1,3 @@
-import * as r from "ramda";
-
 import {prepareRecord} from "../../common/update/error";
 import constants from "../../../constants";
 import invariants from "../invariants";

--- a/src/reducers/map/update/start.test.ts
+++ b/src/reducers/map/update/start.test.ts
@@ -1,4 +1,4 @@
-import * as r from "ramda";
+import * as values from "ramda/src/values"
 import test from "ava";
 
 import constants from "../../../constants";
@@ -48,7 +48,7 @@ test(subject + "adds the record if not there", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 3);
+  t.is(values(updated).length, 3);
 });
 
 test(subject + "doesnt mutate the original", function(t) {
@@ -59,8 +59,8 @@ test(subject + "doesnt mutate the original", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(curr).length, 2);
-  t.is(r.values(updated).length, 3);
+  t.is(values(curr).length, 2);
+  t.is(values(updated).length, 3);
 });
 
 test(subject + "updates existing", function(t) {
@@ -68,7 +68,7 @@ test(subject + "updates existing", function(t) {
   var record = getValid();
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 2);
+  t.is(values(updated).length, 2);
   t.is(updated["2"].id, 2);
   t.is(updated["2"].name, "Green");
 });
@@ -90,7 +90,7 @@ test(subject + "uses the given key", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 1);
+  t.is(values(updated).length, 1);
 });
 
 test(subject + "it throws when record dont have an id", function(t) {

--- a/src/reducers/map/update/start.ts
+++ b/src/reducers/map/update/start.ts
@@ -1,5 +1,3 @@
-import * as r from "ramda";
-
 import {prepareRecord} from "../../common/update/start";
 import constants from "../../../constants";
 import invariants from "../invariants";

--- a/src/reducers/map/update/success.test.ts
+++ b/src/reducers/map/update/success.test.ts
@@ -1,4 +1,5 @@
-import * as r from "ramda";
+import * as values from "ramda/src/values"
+
 import constants from "../../../constants";
 import reducer from "./success";
 import test from "ava";
@@ -51,7 +52,7 @@ test(subject + "adds the record if not there", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 3);
+  t.is(values(updated).length, 3);
 });
 
 test(subject + "doesnt mutate the original collection", function(t) {
@@ -62,8 +63,8 @@ test(subject + "doesnt mutate the original collection", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(curr).length, 2);
-  t.is(r.values(updated).length, 3);
+  t.is(values(curr).length, 2);
+  t.is(values(updated).length, 3);
 });
 
 test(subject + "updates existing", function(t) {
@@ -71,7 +72,7 @@ test(subject + "updates existing", function(t) {
   var record = getValid();
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 2);
+  t.is(values(updated).length, 2);
   t.is(updated["2"].id, 2);
   t.is(updated["2"].name, "Green");
 });
@@ -93,7 +94,7 @@ test(subject + "uses the given key", function(t) {
   };
   var updated = reducer(config, curr, record);
 
-  t.is(r.values(updated).length, 1);
+  t.is(values(updated).length, 1);
 });
 
 test(subject + "it throws when record dont have an id", function(t) {
@@ -120,7 +121,7 @@ test(subject + "removes busy and pendingUpdate", function(t) {
   var record = getValid();
   var updated = reducer(config, curr, record);
 
-  t.deepEqual(r.values(updated).length, 1);
+  t.deepEqual(values(updated).length, 1);
   t.truthy(updated["2"].busy == null, "removes busy");
   t.truthy(updated["2"].pendingUpdate == null, "removes pendingUpdate");
 });

--- a/src/utils/assertAllHaveKeys.ts
+++ b/src/utils/assertAllHaveKeys.ts
@@ -1,9 +1,10 @@
-import * as r from "ramda";
+import * as has from "ramda/src/has"
+import * as all from "ramda/src/all"
 
 export default function(config, reducerName, records) {
   // All given records must have a key
-  var haskey = r.has(config.key);
-  var allKeys = r.all(haskey, records);
+  var haskey = has(config.key);
+  var allKeys = all(haskey, records);
 
   if (!allKeys) {
     throw new Error(

--- a/src/utils/assertNotArray.ts
+++ b/src/utils/assertNotArray.ts
@@ -1,12 +1,12 @@
-import makeScope from "../utils/makeScope";
+import * as is from "ramda/src/is"
 
-import * as r from "ramda";
+import makeScope from "../utils/makeScope";
 
 import {Config, ReducerName} from "../types";
 
 export default function(config: Config, reducerName: ReducerName, record: any) {
   var scope = makeScope(config, reducerName);
-  var isArray = r.is(Array, record);
+  var isArray = is(Array, record);
 
   if (isArray)
     throw new TypeError(scope + ": Expected record not to be an array");

--- a/src/utils/findByKey.ts
+++ b/src/utils/findByKey.ts
@@ -1,9 +1,9 @@
-import * as r from "ramda";
+import * as find from "ramda/src/find"
 
 export default function findByKey(collection, key, id) {
   function predicate(record) {
     return record[key] === id;
   }
 
-  return r.find(predicate, collection);
+  return find(predicate, collection);
 }

--- a/src/utils/wrapArray.ts
+++ b/src/utils/wrapArray.ts
@@ -1,6 +1,6 @@
-import * as r from "ramda";
+import * as is from "ramda/src/is"
 
 export default function wrapArray(recordOrRecords) {
-  var isArray = r.is(Array, recordOrRecords);
+  var isArray = is(Array, recordOrRecords);
   return isArray ? recordOrRecords : [recordOrRecords];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
 		"moduleResolution": "node",
 		"declaration": true,
 		"outDir": "./dist",
-		"target": "es5"
+		"target": "es5",
+		"allowSyntheticDefaultImports": true
 	},
    "exclude": [
 		"dist",


### PR DESCRIPTION
This PR changes ramda imports from

`
import * as r from 'ramda'
r.merge()
`

to

`
import * as merge from 'ramda/src/merge'
merge()
`

which saves the entire library being imported when building projects with redux-crud as a dependency. It's slimmed my vendor build by 9kb (gzipped).

Unfortunately I also ran prettify on the source before committing, which has resulted in a bunch of extra formatting being included in the commit. (It does look nice.) If you don't want this formatting as a part of this commit, let me know and I can submit another PR :)

Hope this is useful, and of course let me know if there's anything that needs changing.

