### PR TITLE
Add the option to pass `partial` in `data` to `updateSuccess`

### DIFF
--- a/src/reducers/common/reducersFor.ts
+++ b/src/reducers/common/reducersFor.ts
@@ -1,4 +1,4 @@
-import * as merge from "ramda/src/merge"
+import * as merge from "ramda/src/merge";
 
 import actionTypesFor from "../../actionTypesFor";
 import constants from "../../constants";
@@ -6,66 +6,71 @@ import constants from "../../constants";
 import {Config, ReducerName} from "../../types";
 
 function reducersFor(resourceName: string, args = {}, emptyState, reducers) {
-  if (resourceName == null)
-    throw new Error("reducersFor: Expected resourceName");
+	if (resourceName == null)
+		throw new Error("reducersFor: Expected resourceName");
 
-  var defaults = {
-    key: constants.DEFAULT_KEY,
-    resourceName: resourceName
-  };
+	var defaults = {
+		key: constants.DEFAULT_KEY,
+		resourceName: resourceName
+	};
 
-  var config = merge(defaults, args);
+	var config = merge(defaults, args);
 
-  return function getReducer(state, action) {
-    state = state || emptyState;
+	return function getReducer(state, action) {
+		state = state || emptyState;
 
-    if (action == null)
-      throw new Error(resourceName + " reducers: Expected action");
+		if (action == null)
+			throw new Error(resourceName + " reducers: Expected action");
 
-    var actionTypes = actionTypesFor(resourceName);
-    var record = action.record;
+		var actionTypes = actionTypesFor(resourceName);
+		var record = action.record;
 
-    switch (action.type) {
-      case actionTypes.fetchSuccess:
-        return reducers.fetchSuccess(
-          config,
-          state,
-          action.records,
-          emptyState,
-          action.data && action.data.replace
-        );
+		switch (action.type) {
+			case actionTypes.fetchSuccess:
+				return reducers.fetchSuccess(
+					config,
+					state,
+					action.records,
+					emptyState,
+					action.data && action.data.replace
+				);
 
-      case actionTypes.createStart:
-        return reducers.createStart(config, state, record);
+			case actionTypes.createStart:
+				return reducers.createStart(config, state, record);
 
-      case actionTypes.createSuccess:
-        return reducers.createSuccess(config, state, record, action.cid);
+			case actionTypes.createSuccess:
+				return reducers.createSuccess(config, state, record, action.cid);
 
-      case actionTypes.createError:
-        return reducers.createError(config, state, record);
+			case actionTypes.createError:
+				return reducers.createError(config, state, record);
 
-      case actionTypes.updateStart:
-        return reducers.updateStart(config, state, record);
+			case actionTypes.updateStart:
+				return reducers.updateStart(config, state, record);
 
-      case actionTypes.updateSuccess:
-        return reducers.updateSuccess(config, state, record);
+			case actionTypes.updateSuccess:
+				return reducers.updateSuccess(
+					config,
+					state,
+					record,
+					action.data && action.data.partial
+				);
 
-      case actionTypes.updateError:
-        return reducers.updateError(config, state, record);
+			case actionTypes.updateError:
+				return reducers.updateError(config, state, record);
 
-      case actionTypes.deleteStart:
-        return reducers.deleteStart(config, state, record);
+			case actionTypes.deleteStart:
+				return reducers.deleteStart(config, state, record);
 
-      case actionTypes.deleteSuccess:
-        return reducers.deleteSuccess(config, state, record);
+			case actionTypes.deleteSuccess:
+				return reducers.deleteSuccess(config, state, record);
 
-      case actionTypes.deleteError:
-        return reducers.deleteError(config, state, record);
+			case actionTypes.deleteError:
+				return reducers.deleteError(config, state, record);
 
-      default:
-        return state;
-    }
-  };
+			default:
+				return state;
+		}
+	};
 }
 
 export default reducersFor;

--- a/src/reducers/list/reducersFor.test.ts
+++ b/src/reducers/list/reducersFor.test.ts
@@ -8,187 +8,201 @@ const current = [{}];
 const user = {};
 const error = "";
 const config = {
-  key: constants.DEFAULT_KEY,
-  resourceName: "users"
+	key: constants.DEFAULT_KEY,
+	resourceName: "users"
 };
 const subject = "reducersFor: ";
 
 test(subject + "calls fetchSuccess", function(t) {
-  const fetchSuccess = td.function();
-  const reducers = reducersFor("users", {}, {fetchSuccess});
+	const fetchSuccess = td.function();
+	const reducers = reducersFor("users", {}, {fetchSuccess});
 
-  var users = [user];
+	var users = [user];
 
-  reducers(current, {
-    records: users,
-    type: "USERS_FETCH_SUCCESS"
-  });
+	reducers(current, {
+		records: users,
+		type: "USERS_FETCH_SUCCESS"
+	});
 
-  td.verify(fetchSuccess(config, current, users, [], undefined));
-  t.pass();
+	td.verify(fetchSuccess(config, current, users, [], undefined));
+	t.pass();
 });
 
 test(subject + "calls fetchSuccess with replace", function(t) {
-  const fetchSuccess = td.function();
-  const reducers = reducersFor("users", {}, {fetchSuccess});
+	const fetchSuccess = td.function();
+	const reducers = reducersFor("users", {}, {fetchSuccess});
 
-  var users = [user];
+	var users = [user];
 
-  reducers(current, {
-    data: {replace: true},
-    records: users,
-    type: "USERS_FETCH_SUCCESS"
-  });
+	reducers(current, {
+		data: {replace: true},
+		records: users,
+		type: "USERS_FETCH_SUCCESS"
+	});
 
-  td.verify(fetchSuccess(config, current, users, [], true));
-  t.pass();
+	td.verify(fetchSuccess(config, current, users, [], true));
+	t.pass();
 });
 
 test(subject + "calls createStart", function(t) {
-  const createStart = td.function();
-  const reducers = reducersFor("users", {}, {createStart});
+	const createStart = td.function();
+	const reducers = reducersFor("users", {}, {createStart});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_CREATE_START"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_CREATE_START"
+	});
 
-  td.verify(createStart(config, current, user));
-  t.pass();
+	td.verify(createStart(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls createSuccess", function(t) {
-  const createSuccess = td.function();
-  const reducers = reducersFor("users", {}, {createSuccess});
+	const createSuccess = td.function();
+	const reducers = reducersFor("users", {}, {createSuccess});
 
-  var cid = "abc";
+	var cid = "abc";
 
-  reducers(current, {
-    record: user,
-    type: "USERS_CREATE_SUCCESS",
-    cid: cid
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_CREATE_SUCCESS",
+		cid: cid
+	});
 
-  td.verify(createSuccess(config, current, user, cid));
-  t.pass();
+	td.verify(createSuccess(config, current, user, cid));
+	t.pass();
 });
 
 test(subject + "calls createError", function(t) {
-  const createError = td.function();
-  const reducers = reducersFor("users", {}, {createError});
+	const createError = td.function();
+	const reducers = reducersFor("users", {}, {createError});
 
-  reducers(current, {
-    error: error,
-    record: user,
-    type: "USERS_CREATE_ERROR"
-  });
+	reducers(current, {
+		error: error,
+		record: user,
+		type: "USERS_CREATE_ERROR"
+	});
 
-  td.verify(createError(config, current, user));
-  t.pass();
+	td.verify(createError(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls updateStart", function(t) {
-  const updateStart = td.function();
-  const reducers = reducersFor("users", {}, {updateStart});
+	const updateStart = td.function();
+	const reducers = reducersFor("users", {}, {updateStart});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_UPDATE_START"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_UPDATE_START"
+	});
 
-  td.verify(updateStart(config, current, user));
-  t.pass();
+	td.verify(updateStart(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls updateSuccess", function(t) {
-  const updateSuccess = td.function();
-  const reducers = reducersFor("users", {}, {updateSuccess});
+	const updateSuccess = td.function();
+	const reducers = reducersFor("users", {}, {updateSuccess});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_UPDATE_SUCCESS"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_UPDATE_SUCCESS"
+	});
 
-  td.verify(updateSuccess(config, current, user));
-  t.pass();
+	td.verify(updateSuccess(config, current, user, undefined));
+	t.pass();
+});
+
+test(subject + "calls updateSuccess with partial", function(t) {
+	const updateSuccess = td.function();
+	const reducers = reducersFor("users", {}, {updateSuccess});
+
+	reducers(current, {
+		data: {partial: true},
+		record: user,
+		type: "USERS_UPDATE_SUCCESS"
+	});
+
+	td.verify(updateSuccess(config, current, user, true));
+	t.pass();
 });
 
 test(subject + "calls updateError", function(t) {
-  const updateError = td.function();
-  const reducers = reducersFor("users", {}, {updateError});
+	const updateError = td.function();
+	const reducers = reducersFor("users", {}, {updateError});
 
-  reducers(current, {
-    error: error,
-    record: user,
-    type: "USERS_UPDATE_ERROR"
-  });
+	reducers(current, {
+		error: error,
+		record: user,
+		type: "USERS_UPDATE_ERROR"
+	});
 
-  td.verify(updateError(config, current, user));
-  t.pass();
+	td.verify(updateError(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls deleteStart", function(t) {
-  const deleteStart = td.function();
-  const reducers = reducersFor("users", {}, {deleteStart});
+	const deleteStart = td.function();
+	const reducers = reducersFor("users", {}, {deleteStart});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_DELETE_START"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_DELETE_START"
+	});
 
-  td.verify(deleteStart(config, current, user));
-  t.pass();
+	td.verify(deleteStart(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls deleteSuccess", function(t) {
-  const deleteSuccess = td.function();
-  const reducers = reducersFor("users", {}, {deleteSuccess});
+	const deleteSuccess = td.function();
+	const reducers = reducersFor("users", {}, {deleteSuccess});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_DELETE_SUCCESS"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_DELETE_SUCCESS"
+	});
 
-  td.verify(deleteSuccess(config, current, user));
-  t.pass();
+	td.verify(deleteSuccess(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls deleteError", function(t) {
-  const deleteError = td.function();
-  const reducers = reducersFor("users", {}, {deleteError});
+	const deleteError = td.function();
+	const reducers = reducersFor("users", {}, {deleteError});
 
-  reducers(current, {
-    error: error,
-    record: user,
-    type: "USERS_DELETE_ERROR"
-  });
+	reducers(current, {
+		error: error,
+		record: user,
+		type: "USERS_DELETE_ERROR"
+	});
 
-  td.verify(deleteError(config, current, user));
-  t.pass();
+	td.verify(deleteError(config, current, user));
+	t.pass();
 });
 
 test(subject + "it passes the given key", function(t) {
-  const createStart = td.function();
-  const reducers = reducersFor("users", {key: "_id"}, {createStart});
+	const createStart = td.function();
+	const reducers = reducersFor("users", {key: "_id"}, {createStart});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_CREATE_START"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_CREATE_START"
+	});
 
-  var expectedConfig = {
-    key: "_id",
-    resourceName: "users"
-  };
+	var expectedConfig = {
+		key: "_id",
+		resourceName: "users"
+	};
 
-  td.verify(createStart(expectedConfig, current, user));
-  t.pass();
+	td.verify(createStart(expectedConfig, current, user));
+	t.pass();
 });
 
 test(subject + "it doesnt mutate the config", function(t) {
-  const config = {};
-  reducersFor("users", config);
-  reducersFor("monkeys", config);
+	const config = {};
+	reducersFor("users", config);
+	reducersFor("monkeys", config);
 
-  t.deepEqual(config, {});
+	t.deepEqual(config, {});
 });

--- a/src/reducers/list/store/merge.ts
+++ b/src/reducers/list/store/merge.ts
@@ -1,32 +1,35 @@
 import wrapArray from "../../../utils/wrapArray";
+import * as mergeDeepRight from "ramda/src/mergeDeepRight";
 
 /*
 Replaces an existing record in a list
 Or adds if not there
 */
-export default function merge(current, records, key) {
-  records = wrapArray(records);
-  var recordMap = {};
-  var indexMap = {};
-  var newRecords = current.slice(0);
+export default function merge(current, records, key, partial = false) {
+	records = wrapArray(records);
+	var recordMap = {};
+	var indexMap = {};
+	var newRecords = current.slice(0);
 
-  current.forEach(function(record, index) {
-    var recordKey = record[key];
-    if (recordKey == null) throw new Error("Expected record to have " + key);
-    recordMap[recordKey] = record;
-    indexMap[recordKey] = index;
-  });
+	current.forEach(function(record, index) {
+		var recordKey = record[key];
+		if (recordKey == null) throw new Error("Expected record to have " + key);
+		recordMap[recordKey] = record;
+		indexMap[recordKey] = index;
+	});
 
-  records.forEach(function(record) {
-    var recordId = record[key];
-    if (recordMap[recordId]) {
-      newRecords[indexMap[recordId]] = record;
-    } else {
-      indexMap[recordId] = newRecords.length;
-      newRecords.push(record);
-    }
-    recordMap[recordId] = record;
-  });
+	records.forEach(function(record) {
+		var recordId = record[key];
+		if (recordMap[recordId]) {
+			newRecords[indexMap[recordId]] = partial
+				? mergeDeepRight(recordMap[recordId], record)
+				: record;
+		} else {
+			indexMap[recordId] = newRecords.length;
+			newRecords.push(record);
+		}
+		recordMap[recordId] = record;
+	});
 
-  return newRecords;
+	return newRecords;
 }

--- a/src/reducers/list/update/success.test.ts
+++ b/src/reducers/list/update/success.test.ts
@@ -3,124 +3,150 @@ import reducer from "./success";
 import test from "ava";
 
 var config = {
-  key: constants.DEFAULT_KEY,
-  resourceName: "users"
+	key: constants.DEFAULT_KEY,
+	resourceName: "users"
 };
 
 var subject = constants.REDUCER_NAMES.UPDATE_SUCCESS;
 
 function getCurrent() {
-  return [
-    {
-      id: 1,
-      name: "Blue",
-      unsaved: true,
-      busy: true
-    },
-    {
-      id: 2,
-      name: "Red",
-      unsaved: true,
-      busy: true
-    }
-  ];
+	return [
+		{
+			id: 1,
+			name: "Blue",
+			unsaved: true,
+			busy: true
+		},
+		{
+			id: 2,
+			name: "Red",
+			unsaved: true,
+			busy: true
+		}
+	];
 }
 
 function getValid() {
-  return {
-    id: 2,
-    name: "Green"
-  };
+	return {
+		id: 2,
+		name: "Green"
+	};
 }
 
 test(subject + "throws if given an array", function(t) {
-  var curr = getCurrent();
-  var record = [];
-  function fn() {
-    reducer(config, curr, record);
-  }
+	var curr = getCurrent();
+	var record = [];
+	function fn() {
+		reducer(config, curr, record);
+	}
 
-  t.throws(fn, TypeError);
+	t.throws(fn, TypeError);
 });
 
 test(subject + "adds the record if not there", function(t) {
-  var curr = getCurrent();
-  var record = {
-    id: 3,
-    name: "Green"
-  };
-  var updated = reducer(config, curr, record);
+	var curr = getCurrent();
+	var record = {
+		id: 3,
+		name: "Green"
+	};
+	var updated = reducer(config, curr, record);
 
-  t.is(updated.length, 3);
+	t.is(updated.length, 3);
 });
 
 test(subject + "doesnt mutate the original collection", function(t) {
-  var curr = getCurrent();
-  var record = {
-    id: 3,
-    name: "Green"
-  };
-  var updated = reducer(config, curr, record);
+	var curr = getCurrent();
+	var record = {
+		id: 3,
+		name: "Green"
+	};
+	var updated = reducer(config, curr, record);
 
-  t.is(curr.length, 2);
-  t.is(updated.length, 3);
+	t.is(curr.length, 2);
+	t.is(updated.length, 3);
+});
+
+test(subject + " merges", function(t) {
+	var curr = [
+		{
+			id: 1,
+			name: "Blue",
+			extra: {
+				untouched: true,
+				value: "extra"
+			}
+		}
+	];
+	var record = {
+		id: 1,
+		extra: {
+			value: "updated"
+		}
+	};
+
+	var updated = reducer(config, curr, record, true);
+
+	t.is(updated[0].id, 1);
+	t.is(updated[0].name, "Blue");
+	t.is(updated[0].extra.untouched, true);
+	t.is(updated[0].extra.value, "updated");
 });
 
 test(subject + "updates existing", function(t) {
-  var curr = getCurrent();
-  var record = getValid();
-  var updated = reducer(config, curr, record);
+	var curr = getCurrent();
+	var record = getValid();
+	var updated = reducer(config, curr, record);
 
-  t.is(updated.length, 2);
-  t.is(updated[1].id, 2);
-  t.is(updated[1].name, "Green");
+	t.is(updated.length, 2);
+	t.is(updated[1].id, 2);
+	t.is(updated[1].name, "Green");
 });
 
 test(subject + "uses the given key", function(t) {
-  var config = {
-    key: "_id",
-    resourceName: "users"
-  };
-  var curr = [
-    {
-      _id: 2,
-      name: "Blue"
-    }
-  ];
-  var record = {
-    _id: 2,
-    name: "Green"
-  };
-  var updated = reducer(config, curr, record);
+	var config = {
+		key: "_id",
+		resourceName: "users"
+	};
+	var curr = [
+		{
+			_id: 2,
+			name: "Blue"
+		}
+	];
+	var record = {
+		_id: 2,
+		name: "Green"
+	};
+	var updated = reducer(config, curr, record);
 
-  t.is(updated.length, 1);
+	t.is(updated.length, 1);
 });
 
 test(subject + "it throws when record dont have an id", function(t) {
-  var curr = getCurrent();
-  var record = {
-    name: "Green"
-  };
+	var curr = getCurrent();
+	var record = {
+		name: "Green"
+	};
 
-  var f = function() {
-    reducer(config, curr, record);
-  };
-  t.throws(f);
+	var f = function() {
+		reducer(config, curr, record);
+	};
+	t.throws(f);
 });
 
 test(subject + "removes busy and pendingUpdate", function(t) {
-  var curr = [
-    {
-      id: 2,
-      name: "Green",
-      pendingUpdate: true,
-      busy: true
-    }
-  ];
-  var record = getValid();
-  var updated = reducer(config, curr, record);
+	var curr = [
+		{
+			id: 2,
+			name: "Green",
+			pendingUpdate: true,
+			busy: true
+		}
+	];
+	var record = getValid();
+	var updated = reducer(config, curr, record);
 
-  t.deepEqual(updated.length, 1);
-  t.truthy(updated[0].busy == null, "removes busy");
-  t.truthy(updated[0].pendingUpdate == null, "removes pendingUpdate");
+	t.deepEqual(updated.length, 1);
+	t.truthy(updated[0].busy == null, "removes busy");
+	t.truthy(updated[0].pendingUpdate == null, "removes pendingUpdate");
 });

--- a/src/reducers/list/update/success.ts
+++ b/src/reducers/list/update/success.ts
@@ -6,16 +6,17 @@ import {Config, InvariantsBaseArgs, ReducerName} from "../../../types";
 
 var reducerName: ReducerName = constants.REDUCER_NAMES.UPDATE_SUCCESS;
 var invariantArgs: InvariantsBaseArgs = {
-  reducerName,
-  canBeArray: false
+	reducerName,
+	canBeArray: false
 };
 
 export default function success(
-  config: Config,
-  current: Array<any>,
-  record: any
+	config: Config,
+	current: Array<any>,
+	record: any,
+	partial: boolean = false
 ): Array<any> {
-  invariants(invariantArgs, config, current, record);
+	invariants(invariantArgs, config, current, record);
 
-  return store.merge(current, record, config.key);
+	return store.merge(current, record, config.key, partial);
 }

--- a/src/reducers/map/reducersFor.test.ts
+++ b/src/reducers/map/reducersFor.test.ts
@@ -8,187 +8,201 @@ const current = [{}];
 const user = {};
 const error = "";
 const config = {
-  key: constants.DEFAULT_KEY,
-  resourceName: "users"
+	key: constants.DEFAULT_KEY,
+	resourceName: "users"
 };
 const subject = "reducersFor: ";
 
 test(subject + "calls fetchSuccess", function(t) {
-  const fetchSuccess = td.function();
-  const reducers = reducersFor("users", {}, {fetchSuccess});
+	const fetchSuccess = td.function();
+	const reducers = reducersFor("users", {}, {fetchSuccess});
 
-  var users = [user];
+	var users = [user];
 
-  reducers(current, {
-    records: users,
-    type: "USERS_FETCH_SUCCESS"
-  });
+	reducers(current, {
+		records: users,
+		type: "USERS_FETCH_SUCCESS"
+	});
 
-  td.verify(fetchSuccess(config, current, users, {}, undefined));
-  t.pass();
+	td.verify(fetchSuccess(config, current, users, {}, undefined));
+	t.pass();
 });
 
 test(subject + "calls fetchSuccess with replace", function(t) {
-  const fetchSuccess = td.function();
-  const reducers = reducersFor("users", {}, {fetchSuccess});
+	const fetchSuccess = td.function();
+	const reducers = reducersFor("users", {}, {fetchSuccess});
 
-  var users = [user];
+	var users = [user];
 
-  reducers(current, {
-    data: {replace: true},
-    records: users,
-    type: "USERS_FETCH_SUCCESS"
-  });
+	reducers(current, {
+		data: {replace: true},
+		records: users,
+		type: "USERS_FETCH_SUCCESS"
+	});
 
-  td.verify(fetchSuccess(config, current, users, {}, true));
-  t.pass();
+	td.verify(fetchSuccess(config, current, users, {}, true));
+	t.pass();
 });
 
 test(subject + "calls createStart", function(t) {
-  const createStart = td.function();
-  const reducers = reducersFor("users", {}, {createStart});
+	const createStart = td.function();
+	const reducers = reducersFor("users", {}, {createStart});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_CREATE_START"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_CREATE_START"
+	});
 
-  td.verify(createStart(config, current, user));
-  t.pass();
+	td.verify(createStart(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls createSuccess", function(t) {
-  const createSuccess = td.function();
-  const reducers = reducersFor("users", {}, {createSuccess});
+	const createSuccess = td.function();
+	const reducers = reducersFor("users", {}, {createSuccess});
 
-  var cid = "abc";
+	var cid = "abc";
 
-  reducers(current, {
-    record: user,
-    type: "USERS_CREATE_SUCCESS",
-    cid: cid
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_CREATE_SUCCESS",
+		cid: cid
+	});
 
-  td.verify(createSuccess(config, current, user, cid));
-  t.pass();
+	td.verify(createSuccess(config, current, user, cid));
+	t.pass();
 });
 
 test(subject + "calls createError", function(t) {
-  const createError = td.function();
-  const reducers = reducersFor("users", {}, {createError});
+	const createError = td.function();
+	const reducers = reducersFor("users", {}, {createError});
 
-  reducers(current, {
-    error: error,
-    record: user,
-    type: "USERS_CREATE_ERROR"
-  });
+	reducers(current, {
+		error: error,
+		record: user,
+		type: "USERS_CREATE_ERROR"
+	});
 
-  td.verify(createError(config, current, user));
-  t.pass();
+	td.verify(createError(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls updateStart", function(t) {
-  const updateStart = td.function();
-  const reducers = reducersFor("users", {}, {updateStart});
+	const updateStart = td.function();
+	const reducers = reducersFor("users", {}, {updateStart});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_UPDATE_START"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_UPDATE_START"
+	});
 
-  td.verify(updateStart(config, current, user));
-  t.pass();
+	td.verify(updateStart(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls updateSuccess", function(t) {
-  const updateSuccess = td.function();
-  const reducers = reducersFor("users", {}, {updateSuccess});
+	const updateSuccess = td.function();
+	const reducers = reducersFor("users", {}, {updateSuccess});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_UPDATE_SUCCESS"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_UPDATE_SUCCESS"
+	});
 
-  td.verify(updateSuccess(config, current, user));
-  t.pass();
+	td.verify(updateSuccess(config, current, user, undefined));
+	t.pass();
+});
+
+test(subject + "calls updateSuccess with partial", function(t) {
+	const updateSuccess = td.function();
+	const reducers = reducersFor("users", {}, {updateSuccess});
+
+	reducers(current, {
+		data: {partial: true},
+		record: user,
+		type: "USERS_UPDATE_SUCCESS"
+	});
+
+	td.verify(updateSuccess(config, current, user, true));
+	t.pass();
 });
 
 test(subject + "calls updateError", function(t) {
-  const updateError = td.function();
-  const reducers = reducersFor("users", {}, {updateError});
+	const updateError = td.function();
+	const reducers = reducersFor("users", {}, {updateError});
 
-  reducers(current, {
-    error: error,
-    record: user,
-    type: "USERS_UPDATE_ERROR"
-  });
+	reducers(current, {
+		error: error,
+		record: user,
+		type: "USERS_UPDATE_ERROR"
+	});
 
-  td.verify(updateError(config, current, user));
-  t.pass();
+	td.verify(updateError(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls deleteStart", function(t) {
-  const deleteStart = td.function();
-  const reducers = reducersFor("users", {}, {deleteStart});
+	const deleteStart = td.function();
+	const reducers = reducersFor("users", {}, {deleteStart});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_DELETE_START"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_DELETE_START"
+	});
 
-  td.verify(deleteStart(config, current, user));
-  t.pass();
+	td.verify(deleteStart(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls deleteSuccess", function(t) {
-  const deleteSuccess = td.function();
-  const reducers = reducersFor("users", {}, {deleteSuccess});
+	const deleteSuccess = td.function();
+	const reducers = reducersFor("users", {}, {deleteSuccess});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_DELETE_SUCCESS"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_DELETE_SUCCESS"
+	});
 
-  td.verify(deleteSuccess(config, current, user));
-  t.pass();
+	td.verify(deleteSuccess(config, current, user));
+	t.pass();
 });
 
 test(subject + "calls deleteError", function(t) {
-  const deleteError = td.function();
-  const reducers = reducersFor("users", {}, {deleteError});
+	const deleteError = td.function();
+	const reducers = reducersFor("users", {}, {deleteError});
 
-  reducers(current, {
-    error: error,
-    record: user,
-    type: "USERS_DELETE_ERROR"
-  });
+	reducers(current, {
+		error: error,
+		record: user,
+		type: "USERS_DELETE_ERROR"
+	});
 
-  td.verify(deleteError(config, current, user));
-  t.pass();
+	td.verify(deleteError(config, current, user));
+	t.pass();
 });
 
 test(subject + "it passes the given key", function(t) {
-  const createStart = td.function();
-  const reducers = reducersFor("users", {key: "_id"}, {createStart});
+	const createStart = td.function();
+	const reducers = reducersFor("users", {key: "_id"}, {createStart});
 
-  reducers(current, {
-    record: user,
-    type: "USERS_CREATE_START"
-  });
+	reducers(current, {
+		record: user,
+		type: "USERS_CREATE_START"
+	});
 
-  var expectedConfig = {
-    key: "_id",
-    resourceName: "users"
-  };
+	var expectedConfig = {
+		key: "_id",
+		resourceName: "users"
+	};
 
-  td.verify(createStart(expectedConfig, current, user));
-  t.pass();
+	td.verify(createStart(expectedConfig, current, user));
+	t.pass();
 });
 
 test(subject + "it doesnt mutate the config", function(t) {
-  const config = {};
-  reducersFor("users", config);
-  reducersFor("monkeys", config);
+	const config = {};
+	reducersFor("users", config);
+	reducersFor("monkeys", config);
 
-  t.deepEqual(config, {});
+	t.deepEqual(config, {});
 });

--- a/src/reducers/map/store/merge.ts
+++ b/src/reducers/map/store/merge.ts
@@ -1,17 +1,21 @@
-import * as merge from "ramda/src/merge"
+import * as merge from "ramda/src/merge";
+import * as mergeDeepRight from "ramda/src/mergeDeepRight";
 
 import {Config, Map} from "../../../types";
 
 /*
-Adds or replace one record
+Replace or merge one record
 */
 export default function replace(
-  config: Config,
-  current: Map<any>,
-  record: any
+	config: Config,
+	current: Map<any>,
+	record: any,
+	partial: boolean = false
 ): Map<any> {
-  var key = config.key;
-  var recordKey = record[key];
+	var key = config.key;
+	var recordKey = record[key];
 
-  return merge(current, {[recordKey]: record});
+	return merge(current, {
+		[recordKey]: partial ? mergeDeepRight(current[recordKey], record) : record
+	});
 }

--- a/src/reducers/map/update/success.test.ts
+++ b/src/reducers/map/update/success.test.ts
@@ -1,127 +1,153 @@
-import * as values from "ramda/src/values"
+import * as values from "ramda/src/values";
 
 import constants from "../../../constants";
 import reducer from "./success";
 import test from "ava";
 
 var config = {
-  key: constants.DEFAULT_KEY,
-  resourceName: "users"
+	key: constants.DEFAULT_KEY,
+	resourceName: "users"
 };
 var subject = constants.REDUCER_NAMES.UPDATE_SUCCESS;
 
 function getCurrent() {
-  return {
-    1: {
-      id: 1,
-      name: "Blue",
-      unsaved: true,
-      busy: true
-    },
-    2: {
-      id: 2,
-      name: "Red",
-      unsaved: true,
-      busy: true
-    }
-  };
+	return {
+		1: {
+			id: 1,
+			name: "Blue",
+			unsaved: true,
+			busy: true
+		},
+		2: {
+			id: 2,
+			name: "Red",
+			unsaved: true,
+			busy: true
+		}
+	};
 }
 
 function getValid() {
-  return {
-    id: 2,
-    name: "Green"
-  };
+	return {
+		id: 2,
+		name: "Green"
+	};
 }
 
 test(subject + "throws if given an array", function(t) {
-  var curr = getCurrent();
-  var record = [];
-  function fn() {
-    reducer(config, curr, record);
-  }
+	var curr = getCurrent();
+	var record = [];
+	function fn() {
+		reducer(config, curr, record);
+	}
 
-  t.throws(fn, TypeError);
+	t.throws(fn, TypeError);
 });
 
 test(subject + "adds the record if not there", function(t) {
-  var curr = getCurrent();
-  var record = {
-    id: 3,
-    name: "Green"
-  };
-  var updated = reducer(config, curr, record);
+	var curr = getCurrent();
+	var record = {
+		id: 3,
+		name: "Green"
+	};
+	var updated = reducer(config, curr, record);
 
-  t.is(values(updated).length, 3);
+	t.is(values(updated).length, 3);
 });
 
 test(subject + "doesnt mutate the original collection", function(t) {
-  var curr = getCurrent();
-  var record = {
-    id: 3,
-    name: "Green"
-  };
-  var updated = reducer(config, curr, record);
+	var curr = getCurrent();
+	var record = {
+		id: 3,
+		name: "Green"
+	};
+	var updated = reducer(config, curr, record);
 
-  t.is(values(curr).length, 2);
-  t.is(values(updated).length, 3);
+	t.is(values(curr).length, 2);
+	t.is(values(updated).length, 3);
 });
 
 test(subject + "updates existing", function(t) {
-  var curr = getCurrent();
-  var record = getValid();
-  var updated = reducer(config, curr, record);
+	var curr = getCurrent();
+	var record = getValid();
+	var updated = reducer(config, curr, record);
 
-  t.is(values(updated).length, 2);
-  t.is(updated["2"].id, 2);
-  t.is(updated["2"].name, "Green");
+	t.is(values(updated).length, 2);
+	t.is(updated["2"].id, 2);
+	t.is(updated["2"].name, "Green");
+});
+
+test(subject + " merges", function(t) {
+	var curr = {
+		1: {
+			id: 1,
+			name: "Blue",
+			extra: {
+				untouched: true,
+				value: "extra"
+			}
+		}
+	};
+	var record = {
+		id: 1,
+		extra: {
+			value: "updated"
+		}
+	};
+
+	var updated = reducer(config, curr, record, true);
+
+	t.is(updated["1"].id, 1);
+	t.is(updated["1"].name, "Blue");
+	t.is(updated["1"].extra.untouched, true);
+	t.is(updated["1"].extra.value, "updated");
 });
 
 test(subject + "uses the given key", function(t) {
-  var config = {
-    key: "_id",
-    resourceName: "users"
-  };
-  var curr = {
-    2: {
-      _id: 2,
-      name: "Blue"
-    }
-  };
-  var record = {
-    _id: 2,
-    name: "Green"
-  };
-  var updated = reducer(config, curr, record);
+	var config = {
+		key: "_id",
+		resourceName: "users"
+	};
+	var curr = {
+		2: {
+			_id: 2,
+			name: "Blue"
+		}
+	};
+	var record = {
+		_id: 2,
+		name: "Green"
+	};
+	var updated = reducer(config, curr, record);
 
-  t.is(values(updated).length, 1);
+	t.is(values(updated).length, 1);
 });
 
 test(subject + "it throws when record dont have an id", function(t) {
-  var curr = getCurrent();
-  var record = {
-    name: "Green"
-  };
+	var curr = getCurrent();
+	var record = {
+		name: "Green"
+	};
 
-  var f = function() {
-    reducer(config, curr, record);
-  };
-  t.throws(f);
+	var f = function() {
+		reducer(config, curr, record);
+	};
+	t.throws(f);
 });
 
 test(subject + "removes busy and pendingUpdate", function(t) {
-  var curr = {
-    2: {
-      id: 2,
-      name: "Green",
-      pendingUpdate: true,
-      busy: true
-    }
-  };
-  var record = getValid();
-  var updated = reducer(config, curr, record);
+	var curr = {
+		2: {
+			id: 2,
+			name: "Green",
+			pendingUpdate: true,
+			busy: true
+		}
+	};
+	var record = getValid();
+	var updated = reducer(config, curr, record);
 
-  t.deepEqual(values(updated).length, 1);
-  t.truthy(updated["2"].busy == null, "removes busy");
-  t.truthy(updated["2"].pendingUpdate == null, "removes pendingUpdate");
+	t.deepEqual(values(updated).length, 1);
+	t.truthy(updated["2"].busy == null, "removes busy");
+	t.truthy(updated["2"].pendingUpdate == null, "removes pendingUpdate");
 });

--- a/src/reducers/map/update/success.ts
+++ b/src/reducers/map/update/success.ts
@@ -6,16 +6,17 @@ import {Config, InvariantsBaseArgs, Map, ReducerName} from "../../../types";
 
 var reducerName: ReducerName = constants.REDUCER_NAMES.UPDATE_SUCCESS;
 var invariantArgs: InvariantsBaseArgs = {
-  reducerName,
-  canBeArray: false
+	reducerName,
+	canBeArray: false
 };
 
 export default function success(
-  config: Config,
-  current: Map<any>,
-  record: any
+	config: Config,
+	current: Map<any>,
+	record: any,
+	partial: boolean = false
 ): Map<any> {
-  invariants(invariantArgs, config, current, record);
+	invariants(invariantArgs, config, current, record);
 
-  return store.merge(config, current, record);
+	return store.merge(config, current, record, partial);
 }


### PR DESCRIPTION
This will cause the update to patch an existing record using ramda's `mergeDeepRight`

Add tests to 'success.test.ts' and 'reducersFor.test.ts' for both list and map

(I think I may have been the first to autoformat according to the .editorconfig too...)